### PR TITLE
 ⭐ 增加对日本验证码短信的识别

### DIFF
--- a/MacCopier/AppDelegate.swift
+++ b/MacCopier/AppDelegate.swift
@@ -160,7 +160,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         let message = getLatestMessage()
         if message != nil {
             let msgText = message!.text
-            if msgText.contains("code") || msgText.contains("码") {
+            if msgText.contains("code") || msgText.contains("码") || msgText.contains("コード") {
                 do {
                     let re = try NSRegularExpression(pattern: codePattern, options: [])
                     let results = re.matches(in: msgText, range: NSRange(location: 0, length: msgText.count))

--- a/MacCopier/AppDelegate.swift
+++ b/MacCopier/AppDelegate.swift
@@ -160,7 +160,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         let message = getLatestMessage()
         if message != nil {
             let msgText = message!.text
-            if msgText.contains("code") || msgText.contains("码") || msgText.contains("コード") {
+            if msgText.contains("code") || msgText.contains("码") || msgText.contains("コード") || msgText.contains("認証番号") {
                 do {
                     let re = try NSRegularExpression(pattern: codePattern, options: [])
                     let results = re.matches(in: msgText, range: NSRange(location: 0, length: msgText.count))


### PR DESCRIPTION
日本验证码通常为这样

```txt
ヤフー 確認コード:8090
このコードは他の人には絶対に教えないでください。
@login.yahoo.co.jp #8090
```

```text
認証番号:2912 この番号を入力してください。番号の有効期限は 10 分です。イープラスより。
```

```txt
[J:COM]下記の確認コードを画面に入力してください。
確認コード
489767
```

```txt
[menu]認証コード 8497543
アプリの認証画面でコードを入力してください。
```

已通过本地测试可以正常识别